### PR TITLE
fix: ignore eslint caution during builds

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -4,7 +4,12 @@ const withBundleAnalyzer = require('@next/bundle-analyzer')({
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  // any configs you need
+  eslint: {
+    // Warning: This allows production builds to successfully complete even if
+    // your project has ESLint errors.
+    ignoreDuringBuilds: true,
+  },
+
 }
 
 module.exports = withBundleAnalyzer(nextConfig)


### PR DESCRIPTION
## 요약 📜
- eslint로 인한 build 실패

## 구현 내용 📝
- next.config.js에 [eslint](https://nextjs.org/docs/pages/api-reference/next-config-js/eslint) 룰 추가

## 관련 이슈🎯
