### PR TITLE
fix: 메인 페이지 초기 로딩 속도 문제 해결

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "remark": "^14.0.2",
     "remark-html": "^15.0.1",
     "remark-prism": "^1.3.6",
-    "swr": "2.2.5"
+    "swr": "2.2.5",
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "@next/bundle-analyzer": "^12.3.1",

--- a/src/common/util/fs.ts
+++ b/src/common/util/fs.ts
@@ -1,9 +1,7 @@
 import fs from 'fs';
 
-type Option = Parameters<typeof fs.readFileSync>['1'];
-
 export class File {
-  static getFile(path: fs.PathLike, option: Option) {
+  static getFile(path: fs.PathLike, option: BufferEncoding) {
     return fs.readFileSync(path, option);
   }
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -3,19 +3,11 @@ import useSWR from 'swr';
 
 import Layout from '../shared/component/layout';
 import {
+  type PostMeta,
   PostService,
 } from '../shared/service/post.service';
 
 const KEY_POST = '/api/posts';
-
-interface Posts {
-  title: string;
-  date: string;
-  description: string;
-  thumbnail: string;
-  slug: string;
-  keyword: string;
-}
 
 export const getStaticProps = async () => {
   const postMetaList = await PostService.getMetaList();
@@ -30,7 +22,7 @@ export const getStaticProps = async () => {
 };
 
 function PostNames() {
-  const { data: postMetaList } = useSWR<Posts[]>(KEY_POST);
+  const { data: postMetaList } = useSWR<Array<PostMeta>>(KEY_POST);
 
   return (
     <ul>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -18,23 +18,23 @@ interface Posts {
 }
 
 export const getStaticProps = async () => {
-  const postsMeta = await PostService.getPostMetas();
+  const postMetaList = await PostService.getPostMetaList();
 
   return {
     props: {
       fallback: {
-        [KEY_POST]: postsMeta,
+        [KEY_POST]: postMetaList,
       },
     },
   };
 };
 
 function PostNames() {
-  const { data: posts } = useSWR<Posts[]>(KEY_POST);
+  const { data: postMetaList } = useSWR<Posts[]>(KEY_POST);
 
   return (
     <ul>
-      {posts?.map((post) => (
+      {postMetaList?.map((post) => (
         <li
           className="title-card"
           key={post.keyword}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -18,7 +18,7 @@ interface Posts {
 }
 
 export const getStaticProps = async () => {
-  const postMetaList = await PostService.getPostMetaList();
+  const postMetaList = await PostService.getMetaList();
 
   return {
     props: {

--- a/src/pages/posts/[id].tsx
+++ b/src/pages/posts/[id].tsx
@@ -18,7 +18,7 @@ export const getStaticPaths = () => {
 export const getStaticProps = async (
   { params }: { params: { id: string; }; },
 ) => {
-  const post = await PostService.getPostHTML(params.id);
+  const post = await PostService.getHTML(params.id);
   const KEY = `/api/posts/${params.id}`;
 
   return { props: { fallback: { [KEY]: post } } };

--- a/src/pages/posts/[id].tsx
+++ b/src/pages/posts/[id].tsx
@@ -18,7 +18,7 @@ export const getStaticPaths = () => {
 export const getStaticProps = async (
   { params }: { params: { id: string; }; },
 ) => {
-  const post = await PostService.getPost(params.id);
+  const post = await PostService.getPostHTML(params.id);
   const KEY = `/api/posts/${params.id}`;
 
   return { props: { fallback: { [KEY]: post } } };

--- a/src/shared/service/post.service.ts
+++ b/src/shared/service/post.service.ts
@@ -6,17 +6,13 @@ import path from 'path';
 import { File } from '../../common/util/fs';
 
 export class PostService {
-  static async markdownToHTML(markdown: string) {
+  private static async markdownToHTML(markdown: string) {
     const result = await remark()
       .use(html, { sanitize: false })
       .use(remarkPrism)
       .process(markdown);
 
     return result.toString();
-  }
-
-  static getAllPostNames() {
-    return File.getFileNamesInDirectory('__posts');
   }
 
   private static getPostFile(id: string) {
@@ -26,14 +22,7 @@ export class PostService {
     return fileContent;
   }
 
-  static async getPostHTML(id: string) {
-    const { html: htmlLikes, meta } = await PostService.getParsedPost(id);
-    const HTML = await PostService.markdownToHTML(htmlLikes);
-
-    return { html: HTML, meta };
-  }
-
-  static async getParsedPost(id: string) {
+  private static parsePost(id: string) {
     const md = this.getPostFile(id);
     const { data: meta, content } = matter(md);
 
@@ -46,14 +35,23 @@ export class PostService {
     return new Date(b.date).getTime() - new Date(a.date).getTime();
   }
 
-  static async getPostMetaList() {
-    const posts = PostService.getAllPostNames()
-      .map((fileName) => PostService.getParsedPost(fileName));
+  public static getAllPostNames() {
+    return File.getFileNamesInDirectory('__posts');
+  }
 
-    const postMetas = await Promise.allSettled(posts)
-      .then((res) => res.map((res: any) => res.value.meta))
-      .then((res) => res.sort(PostService.sortByDescendingForFileName));
+  public static async getHTML(id: string) {
+    const { html: htmlLikes, meta } = PostService.parsePost(id);
+    const HTML = await PostService.markdownToHTML(htmlLikes);
 
-    return postMetas;
+    return { html: HTML, meta };
+  }
+
+  public static async getMetaList() {
+    const postsMetaList = PostService.getAllPostNames()
+      .map((fileName) => PostService.parsePost(fileName))
+      .map((post) => post.meta)
+      .sort(PostService.sortByDescendingForFileName);
+
+    return postsMetaList;
   }
 }

--- a/src/shared/service/post.service.ts
+++ b/src/shared/service/post.service.ts
@@ -53,9 +53,9 @@ export class PostService {
     return new Date(b.date).getTime() - new Date(a.date).getTime();
   }
 
-  static async getPostMetas() {
+  static async getPostMetaList() {
     const posts = PostService.getAllPostNames()
-      .map((fileNames) => PostService.getPost(fileNames));
+      .map((fileName) => PostService.getPost(fileName));
 
     const postMetas = await Promise.allSettled(posts)
       .then((res) => res.map((res: any) => res.value.meta))

--- a/yarn.lock
+++ b/yarn.lock
@@ -4534,6 +4534,11 @@ yocto-queue@^0.1.0:
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
 
+zod@^3.23.8:
+  version "3.23.8"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-3.23.8.tgz#e37b957b5d52079769fb8097099b592f0ef4067d"
+  integrity sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==
+
 zwitch@^2.0.0, zwitch@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/zwitch/-/zwitch-2.0.4.tgz#c827d4b0acb76fc3e685a4c6ec2902d51070e9d7"


### PR DESCRIPTION
## 요약 📜
- #7 문제 해결

## 구현 내용 📝

### AS-IS
https://github.com/SaeWooKKang/next-blog/assets/87258182/6a4b34b1-cfa6-4a91-927b-c9fe6a727d39

- issue에서 시간이 많이걸렸던 getPostMetas 함수는 meta 정보와 html을 반환하는데 확인 결과 `.md` 파일을 html로 직렬화하는 함수가 약 총 5.3s로  전체 페이지 로딩 5.817s의 약 **92%** 차지 

### TO-BE

https://github.com/SaeWooKKang/next-blog/assets/87258182/703b732b-70d8-458e-a846-ee192624752b
- `/` 페이지에선 메타 정보만 필요하고, HTML로 직렬화가 불필요하므로 함수를 메타 정보 파싱과, html 직렬화 하는 함수 2개로 분리
  - [refactor: 메인페이지 로딩 속도 개선](https://github.com/SaeWooKKang/next-blog/commit/8781ca9b295194afe625bb890a25aa405c97b1eb) 
- 약 5.8s -> 약 1.6s로 약 **3.6**배 속도 향상

## 관련 이슈🎯
- 처음에는 파싱 함수의 반환값을 캐싱하면 해결될거라고 생각했는데 캐싱이 되기전인 초기 로딩 속도는 여전히 느려서 근본적 문제를 해결하고자 함
  - [feat: 캐시를 활용하여 파일 읽기, html 태그로 변환 시간 단축](https://github.com/SaeWooKKang/next-blog/commit/82e070af76bf6c09a346c1fefdfe7331c5bc1c15)

## 기타
- zod로 `.md`파일의 meta 데이터 스키마 검증을 통해 any 타입 제거
